### PR TITLE
Add support for new API key: owner.userDirectoryConnectorName

### DIFF
--- a/qlik_sense/__init__.py
+++ b/qlik_sense/__init__.py
@@ -1,5 +1,5 @@
 """This library is a python client for the Qlik Sense APIs"""
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 name = 'qlik_sense'
 
 from qlik_sense.clients import NTLMClient, SSLClient

--- a/qlik_sense/models/user.py
+++ b/qlik_sense/models/user.py
@@ -15,6 +15,7 @@ class UserCondensed(EntityCondensed):
     """
     user_name: str = field(default=None, hash=True)
     user_directory: str = field(default=None, hash=True)
+    user_directory_connector: str = field(default=None, hash=True)
 
 
 class UserCondensedSchema(EntityCondensedSchema):
@@ -23,6 +24,9 @@ class UserCondensedSchema(EntityCondensedSchema):
     """
     user_name: str = ma.fields.Str(required=True, data_key='userId')
     user_directory: str = ma.fields.Str(required=True, data_key='userDirectory')
+    user_directory_connector: str = ma.fields.Str(
+        required=True, data_key='userDirectoryConnectorName'
+    )
 
     @ma.pre_dump()
     def pre_dump(self, data: 'Union[UserCondensed, dict]', **kwargs) -> dict:


### PR DESCRIPTION
Adding support for the new `owner.userDirectoryConnectorName` key in the Qliksense API response as a possible solution to #5. 

Willing to discuss a better option.